### PR TITLE
bind: silence warning with gcc

### DIFF
--- a/include/boost/bind/arg.hpp
+++ b/include/boost/bind/arg.hpp
@@ -22,6 +22,11 @@
 #include <boost/config.hpp>
 #include <boost/is_placeholder.hpp>
 
+#if BOOST_GCC >= 40700
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#endif
+
 namespace boost
 {
 
@@ -56,5 +61,10 @@ template< int I > struct is_placeholder< arg<I> (*) () >
 
 
 } // namespace boost
+
+#if BOOST_GCC >= 40700
+#pragma GCC diagnostic pop
+#endif
+
 
 #endif // #ifndef BOOST_BIND_ARG_HPP_INCLUDED


### PR DESCRIPTION
workaround for https://svn.boost.org/trac/boost/ticket/8971
