### PR TITLE
Link to compose in old version of boost.

### DIFF
--- a/bind.html
+++ b/bind.html
@@ -272,7 +272,7 @@ bind(&amp;X::f, p, _1)(i);			// (<i>internal copy of p</i>)-&gt;f(i)
 		</p>
 		<P>This feature of <b>bind</b> can be used to perform function composition. See <A href="bind_as_compose.cpp">
 				bind_as_compose.cpp</A> for an example that demonstrates how to use <b>bind</b>
-			to achieve similar functionality to <A href="../compose/index.htm">Boost.Compose</A>.
+			to achieve similar functionality to <A href="http://www.boost.org/doc/libs/1_31_0/libs/compose/index.htm">Boost.Compose</A>.
 		</P>
 		<p>Note that the first argument - the bound function object - is not evaluated, 
 			even when it's a function object that is produced by <STRONG>bind</STRONG> or a 

--- a/mem_fn.html
+++ b/mem_fn.html
@@ -145,7 +145,7 @@ void k(std::vector&lt;boost::shared_ptr&lt;X&gt; &gt; const &amp; v)
 		<p>
 			Yes. For simple uses, <b>mem_fn</b> provides additional functionality that the 
 			standard adaptors do not. Complicated expressions that use <b>std::bind1st</b>, <b>std::bind2nd</b>
-			or <a href="../compose/index.htm"><b>Boost.Compose</b></a> along with the 
+			or <a href="http://www.boost.org/doc/libs/1_31_0/libs/compose/index.htm"><b>Boost.Compose</b></a> along with the 
 			standard adaptors can be rewritten using <a href="bind.html"><b>boost::bind</b></a>
 			that automatically takes advantage of <b>mem_fn</b>.
 		</p>


### PR DESCRIPTION
Compose isn't included in modular boost, so there's nothing to link to.
I changed it to link to an old version which still has compose
documentation. It might be better to rewrite it?
