### PR TITLE
Completed support for bind<void>. Added test case.

### DIFF
--- a/include/boost/bind/bind_mf_cc.hpp
+++ b/include/boost/bind/bind_mf_cc.hpp
@@ -34,6 +34,26 @@ template<class R, class T,
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1));
 }
 
+template<class Rt2, class R, class T,
+    class A1>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf0)<R, T>, typename _bi::list_av_1<A1>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (), A1 a1)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf0)<R, T> F;
+    typedef typename _bi::list_av_1<A1>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1));
+}
+
+template<class Rt2, class R, class T,
+    class A1>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf0)<R, T>, typename _bi::list_av_1<A1>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) () const, A1 a1)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf0)<R, T> F;
+    typedef typename _bi::list_av_1<A1>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1));
+}
+
 // 1
 
 template<class R, class T,
@@ -56,6 +76,28 @@ template<class R, class T,
     typedef _mfi::BOOST_BIND_MF_NAME(cmf1)<R, T, B1> F;
     typedef typename _bi::list_av_2<A1, A2>::type list_type;
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2));
+}
+
+template<class Rt2, class R, class T,
+    class B1,
+    class A1, class A2>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf1)<R, T, B1>, typename _bi::list_av_2<A1, A2>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1), A1 a1, A2 a2)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf1)<R, T, B1> F;
+    typedef typename _bi::list_av_2<A1, A2>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2));
+}
+
+template<class Rt2, class R, class T,
+    class B1,
+    class A1, class A2>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf1)<R, T, B1>, typename _bi::list_av_2<A1, A2>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1) const, A1 a1, A2 a2)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf1)<R, T, B1> F;
+    typedef typename _bi::list_av_2<A1, A2>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2));
 }
 
 // 2
@@ -82,6 +124,28 @@ template<class R, class T,
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3));
 }
 
+template<class Rt2, class R, class T,
+    class B1, class B2,
+    class A1, class A2, class A3>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf2)<R, T, B1, B2>, typename _bi::list_av_3<A1, A2, A3>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2), A1 a1, A2 a2, A3 a3)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf2)<R, T, B1, B2> F;
+    typedef typename _bi::list_av_3<A1, A2, A3>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2,
+    class A1, class A2, class A3>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf2)<R, T, B1, B2>, typename _bi::list_av_3<A1, A2, A3>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2) const, A1 a1, A2 a2, A3 a3)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf2)<R, T, B1, B2> F;
+    typedef typename _bi::list_av_3<A1, A2, A3>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3));
+}
+
 // 3
 
 template<class R, class T,
@@ -104,6 +168,28 @@ template<class R, class T,
     typedef _mfi::BOOST_BIND_MF_NAME(cmf3)<R, T, B1, B2, B3> F;
     typedef typename _bi::list_av_4<A1, A2, A3, A4>::type list_type;
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3,
+    class A1, class A2, class A3, class A4>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf3)<R, T, B1, B2, B3>, typename _bi::list_av_4<A1, A2, A3, A4>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3), A1 a1, A2 a2, A3 a3, A4 a4)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf3)<R, T, B1, B2, B3> F;
+    typedef typename _bi::list_av_4<A1, A2, A3, A4>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3,
+    class A1, class A2, class A3, class A4>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf3)<R, T, B1, B2, B3>, typename _bi::list_av_4<A1, A2, A3, A4>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3) const, A1 a1, A2 a2, A3 a3, A4 a4)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf3)<R, T, B1, B2, B3> F;
+    typedef typename _bi::list_av_4<A1, A2, A3, A4>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4));
 }
 
 // 4
@@ -130,6 +216,28 @@ template<class R, class T,
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5));
 }
 
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4,
+    class A1, class A2, class A3, class A4, class A5>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf4)<R, T, B1, B2, B3, B4>, typename _bi::list_av_5<A1, A2, A3, A4, A5>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4), A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf4)<R, T, B1, B2, B3, B4> F;
+    typedef typename _bi::list_av_5<A1, A2, A3, A4, A5>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4,
+    class A1, class A2, class A3, class A4, class A5>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf4)<R, T, B1, B2, B3, B4>, typename _bi::list_av_5<A1, A2, A3, A4, A5>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4) const, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf4)<R, T, B1, B2, B3, B4> F;
+    typedef typename _bi::list_av_5<A1, A2, A3, A4, A5>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5));
+}
+
 // 5
 
 template<class R, class T,
@@ -152,6 +260,28 @@ template<class R, class T,
     typedef _mfi::BOOST_BIND_MF_NAME(cmf5)<R, T, B1, B2, B3, B4, B5> F;
     typedef typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type list_type;
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5,
+    class A1, class A2, class A3, class A4, class A5, class A6>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf5)<R, T, B1, B2, B3, B4, B5>, typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5), A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf5)<R, T, B1, B2, B3, B4, B5> F;
+    typedef typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5,
+    class A1, class A2, class A3, class A4, class A5, class A6>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf5)<R, T, B1, B2, B3, B4, B5>, typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5) const, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf5)<R, T, B1, B2, B3, B4, B5> F;
+    typedef typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6));
 }
 
 // 6
@@ -178,6 +308,28 @@ template<class R, class T,
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7));
 }
 
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf6)<R, T, B1, B2, B3, B4, B5, B6>, typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6), A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf6)<R, T, B1, B2, B3, B4, B5, B6> F;
+    typedef typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf6)<R, T, B1, B2, B3, B4, B5, B6>, typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6) const, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf6)<R, T, B1, B2, B3, B4, B5, B6> F;
+    typedef typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7));
+}
+
 // 7
 
 template<class R, class T,
@@ -202,6 +354,28 @@ template<class R, class T,
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8));
 }
 
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6, class B7,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf7)<R, T, B1, B2, B3, B4, B5, B6, B7>, typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7), A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf7)<R, T, B1, B2, B3, B4, B5, B6, B7> F;
+    typedef typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6, class B7,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf7)<R, T, B1, B2, B3, B4, B5, B6, B7>, typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7) const, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf7)<R, T, B1, B2, B3, B4, B5, B6, B7> F;
+    typedef typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8));
+}
+
 // 8
 
 template<class R, class T,
@@ -224,4 +398,26 @@ template<class R, class T,
     typedef _mfi::BOOST_BIND_MF_NAME(cmf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8> F;
     typedef typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type list_type;
     return _bi::bind_t<R, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8, a9));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6, class B7, class B8,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8>, typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7, B8), A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(mf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8> F;
+    typedef typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8, a9));
+}
+
+template<class Rt2, class R, class T,
+    class B1, class B2, class B3, class B4, class B5, class B6, class B7, class B8,
+    class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9>
+    _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8>, typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type>
+    BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7, B8) const, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
+{
+    typedef _mfi::BOOST_BIND_MF_NAME(cmf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8> F;
+    typedef typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type list_type;
+    return _bi::bind_t<Rt2, F, list_type>(F(f), list_type(a1, a2, a3, a4, a5, a6, a7, a8, a9));
 }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -29,6 +29,8 @@ test-suite "bind"
       [ run bind_rvalue_test.cpp ]
       [ run bind_and_or_test.cpp ]
       [ run bind_void_test.cpp ]
+      [ run bind_void_dm_test.cpp ]
+      [ run bind_void_mf_test.cpp ]
       [ run mem_fn_test.cpp ]
       [ run mem_fn_void_test.cpp ]
       [ run mem_fn_derived_test.cpp ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -28,6 +28,7 @@ test-suite "bind"
       [ run bind_placeholder_test.cpp ]
       [ run bind_rvalue_test.cpp ]
       [ run bind_and_or_test.cpp ]
+      [ run bind_void_test.cpp ]
       [ run mem_fn_test.cpp ]
       [ run mem_fn_void_test.cpp ]
       [ run mem_fn_derived_test.cpp ]

--- a/test/bind_void_dm_test.cpp
+++ b/test/bind_void_dm_test.cpp
@@ -1,0 +1,72 @@
+#include <boost/config.hpp>
+
+#if defined(BOOST_MSVC)
+#pragma warning(disable: 4786)  // identifier truncated in debug info
+#pragma warning(disable: 4710)  // function not inlined
+#pragma warning(disable: 4711)  // function selected for automatic inline expansion
+#pragma warning(disable: 4514)  // unreferenced inline removed
+#endif
+
+//
+//  bind_void_mf_test.cpp - test for bind<void> with member functions
+//
+//  Copyright (c) 2008 Peter Dimov
+//  Copyright (c) 2014 Agustin Berge
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(push, 3)
+#endif
+
+#include <iostream>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(pop)
+#endif
+
+#include <boost/detail/lightweight_test.hpp>
+
+//
+
+struct Z
+{
+    int m;
+};
+
+void member_data_test()
+{
+    Z z = { 17041 };
+    Z * pz = &z;
+
+    boost::bind<void>( &Z::m, _1 )( z );
+    boost::bind<void>( &Z::m, _1 )( pz );
+
+    boost::bind<void>( &Z::m, z )();
+    boost::bind<void>( &Z::m, pz )();
+    boost::bind<void>( &Z::m, boost::ref(z) )();
+
+
+    Z const cz = z;
+    Z const * pcz = &cz;
+
+    boost::bind<void>( &Z::m, _1 )( cz );
+    boost::bind<void>( &Z::m, _1 )( pcz );
+
+    boost::bind<void>( &Z::m, cz )();
+    boost::bind<void>( &Z::m, pcz )();
+    boost::bind<void>( &Z::m, boost::ref(cz) )();
+}
+
+int main()
+{
+    member_data_test();
+
+    return boost::report_errors();
+}

--- a/test/bind_void_mf_test.cpp
+++ b/test/bind_void_mf_test.cpp
@@ -1,0 +1,171 @@
+#include <boost/config.hpp>
+
+#if defined(BOOST_MSVC)
+#pragma warning(disable: 4786)  // identifier truncated in debug info
+#pragma warning(disable: 4710)  // function not inlined
+#pragma warning(disable: 4711)  // function selected for automatic inline expansion
+#pragma warning(disable: 4514)  // unreferenced inline removed
+#endif
+
+//
+//  bind_void_mf_test.cpp - test for bind<void> with member functions
+//
+//  Copyright (c) 2008 Peter Dimov
+//  Copyright (c) 2014 Agustin Berge
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(push, 3)
+#endif
+
+#include <iostream>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(pop)
+#endif
+
+#include <boost/detail/lightweight_test.hpp>
+
+//
+
+long global_result;
+
+//
+
+struct X
+{
+    mutable unsigned int hash;
+
+    X(): hash(0) {}
+
+    int f0() { f1(17); return 0; }
+    int g0() const { g1(17); return 0; }
+
+    int f1(int a1) { hash = (hash * 17041 + a1) % 32768; return 0; }
+    int g1(int a1) const { hash = (hash * 17041 + a1 * 2) % 32768; return 0; }
+
+    int f2(int a1, int a2) { f1(a1); f1(a2); return 0; }
+    int g2(int a1, int a2) const { g1(a1); g1(a2); return 0; }
+
+    int f3(int a1, int a2, int a3) { f2(a1, a2); f1(a3); return 0; }
+    int g3(int a1, int a2, int a3) const { g2(a1, a2); g1(a3); return 0; }
+
+    int f4(int a1, int a2, int a3, int a4) { f3(a1, a2, a3); f1(a4); return 0; }
+    int g4(int a1, int a2, int a3, int a4) const { g3(a1, a2, a3); g1(a4); return 0; }
+
+    int f5(int a1, int a2, int a3, int a4, int a5) { f4(a1, a2, a3, a4); f1(a5); return 0; }
+    int g5(int a1, int a2, int a3, int a4, int a5) const { g4(a1, a2, a3, a4); g1(a5); return 0; }
+
+    int f6(int a1, int a2, int a3, int a4, int a5, int a6) { f5(a1, a2, a3, a4, a5); f1(a6); return 0; }
+    int g6(int a1, int a2, int a3, int a4, int a5, int a6) const { g5(a1, a2, a3, a4, a5); g1(a6); return 0; }
+
+    int f7(int a1, int a2, int a3, int a4, int a5, int a6, int a7) { f6(a1, a2, a3, a4, a5, a6); f1(a7); return 0; }
+    int g7(int a1, int a2, int a3, int a4, int a5, int a6, int a7) const { g6(a1, a2, a3, a4, a5, a6); g1(a7); return 0; }
+
+    int f8(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8) { f7(a1, a2, a3, a4, a5, a6, a7); f1(a8); return 0; }
+    int g8(int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8) const { g7(a1, a2, a3, a4, a5, a6, a7); g1(a8); return 0; }
+};
+
+void member_function_test()
+{
+    using namespace boost;
+
+    X x;
+
+    // 0
+
+    bind<void>(&X::f0, &x)();
+    bind<void>(&X::f0, ref(x))();
+
+    bind<void>(&X::g0, &x)();
+    bind<void>(&X::g0, x)();
+    bind<void>(&X::g0, ref(x))();
+
+    // 1
+
+    bind<void>(&X::f1, &x, 1)();
+    bind<void>(&X::f1, ref(x), 1)();
+
+    bind<void>(&X::g1, &x, 1)();
+    bind<void>(&X::g1, x, 1)();
+    bind<void>(&X::g1, ref(x), 1)();
+
+    // 2
+
+    bind<void>(&X::f2, &x, 1, 2)();
+    bind<void>(&X::f2, ref(x), 1, 2)();
+
+    bind<void>(&X::g2, &x, 1, 2)();
+    bind<void>(&X::g2, x, 1, 2)();
+    bind<void>(&X::g2, ref(x), 1, 2)();
+
+    // 3
+
+    bind<void>(&X::f3, &x, 1, 2, 3)();
+    bind<void>(&X::f3, ref(x), 1, 2, 3)();
+
+    bind<void>(&X::g3, &x, 1, 2, 3)();
+    bind<void>(&X::g3, x, 1, 2, 3)();
+    bind<void>(&X::g3, ref(x), 1, 2, 3)();
+
+    // 4
+
+    bind<void>(&X::f4, &x, 1, 2, 3, 4)();
+    bind<void>(&X::f4, ref(x), 1, 2, 3, 4)();
+
+    bind<void>(&X::g4, &x, 1, 2, 3, 4)();
+    bind<void>(&X::g4, x, 1, 2, 3, 4)();
+    bind<void>(&X::g4, ref(x), 1, 2, 3, 4)();
+
+    // 5
+
+    bind<void>(&X::f5, &x, 1, 2, 3, 4, 5)();
+    bind<void>(&X::f5, ref(x), 1, 2, 3, 4, 5)();
+
+    bind<void>(&X::g5, &x, 1, 2, 3, 4, 5)();
+    bind<void>(&X::g5, x, 1, 2, 3, 4, 5)();
+    bind<void>(&X::g5, ref(x), 1, 2, 3, 4, 5)();
+
+    // 6
+
+    bind<void>(&X::f6, &x, 1, 2, 3, 4, 5, 6)();
+    bind<void>(&X::f6, ref(x), 1, 2, 3, 4, 5, 6)();
+
+    bind<void>(&X::g6, &x, 1, 2, 3, 4, 5, 6)();
+    bind<void>(&X::g6, x, 1, 2, 3, 4, 5, 6)();
+    bind<void>(&X::g6, ref(x), 1, 2, 3, 4, 5, 6)();
+
+    // 7
+
+    bind<void>(&X::f7, &x, 1, 2, 3, 4, 5, 6, 7)();
+    bind<void>(&X::f7, ref(x), 1, 2, 3, 4, 5, 6, 7)();
+
+    bind<void>(&X::g7, &x, 1, 2, 3, 4, 5, 6, 7)();
+    bind<void>(&X::g7, x, 1, 2, 3, 4, 5, 6, 7)();
+    bind<void>(&X::g7, ref(x), 1, 2, 3, 4, 5, 6, 7)();
+
+    // 8
+
+    bind<void>(&X::f8, &x, 1, 2, 3, 4, 5, 6, 7, 8)();
+    bind<void>(&X::f8, ref(x), 1, 2, 3, 4, 5, 6, 7, 8)();
+
+    bind<void>(&X::g8, &x, 1, 2, 3, 4, 5, 6, 7, 8)();
+    bind<void>(&X::g8, x, 1, 2, 3, 4, 5, 6, 7, 8)();
+    bind<void>(&X::g8, ref(x), 1, 2, 3, 4, 5, 6, 7, 8)();
+
+    BOOST_TEST( x.hash == 23558 );
+}
+
+int main()
+{
+    member_function_test();
+
+    return boost::report_errors();
+}

--- a/test/bind_void_test.cpp
+++ b/test/bind_void_test.cpp
@@ -1,0 +1,139 @@
+#include <boost/config.hpp>
+
+#if defined(BOOST_MSVC)
+#pragma warning(disable: 4786)  // identifier truncated in debug info
+#pragma warning(disable: 4710)  // function not inlined
+#pragma warning(disable: 4711)  // function selected for automatic inline expansion
+#pragma warning(disable: 4514)  // unreferenced inline removed
+#endif
+
+//
+//  bind_void_test.cpp - test for bind<void>
+//
+//  Copyright (c) 2008 Peter Dimov
+//  Copyright (c) 2014 Agustin Berge
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/bind.hpp>
+#include <boost/ref.hpp>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(push, 3)
+#endif
+
+#include <iostream>
+
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1300)
+#pragma warning(pop)
+#endif
+
+#include <boost/detail/lightweight_test.hpp>
+
+//
+
+long global_result;
+
+long f_0()
+{
+    return global_result = 17041L;
+}
+
+long f_1(long a)
+{
+    return global_result = a;
+}
+
+long f_2(long a, long b)
+{
+    return global_result = a + 10 * b;
+}
+
+long f_3(long a, long b, long c)
+{
+    return global_result = a + 10 * b + 100 * c;
+}
+
+long f_4(long a, long b, long c, long d)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d;
+}
+
+long f_5(long a, long b, long c, long d, long e)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e;
+}
+
+long f_6(long a, long b, long c, long d, long e, long f)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e + 100000 * f;
+}
+
+long f_7(long a, long b, long c, long d, long e, long f, long g)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e + 100000 * f + 1000000 * g;
+}
+
+long f_8(long a, long b, long c, long d, long e, long f, long g, long h)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e + 100000 * f + 1000000 * g + 10000000 * h;
+}
+
+long f_9(long a, long b, long c, long d, long e, long f, long g, long h, long i)
+{
+    return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e + 100000 * f + 1000000 * g + 10000000 * h + 100000000 * i;
+}
+
+void function_test()
+{
+    using namespace boost;
+
+    int const i = 1;
+
+    BOOST_TEST( (bind<void>(f_0)(i), (global_result == 17041L)) );
+    BOOST_TEST( (bind<void>(f_1, _1)(i), (global_result == 1L)) );
+    BOOST_TEST( (bind<void>(f_2, _1, 2)(i), (global_result == 21L)) );
+    BOOST_TEST( (bind<void>(f_3, _1, 2, 3)(i), (global_result == 321L)) );
+    BOOST_TEST( (bind<void>(f_4, _1, 2, 3, 4)(i), (global_result == 4321L)) );
+    BOOST_TEST( (bind<void>(f_5, _1, 2, 3, 4, 5)(i), (global_result == 54321L)) );
+    BOOST_TEST( (bind<void>(f_6, _1, 2, 3, 4, 5, 6)(i), (global_result == 654321L)) );
+    BOOST_TEST( (bind<void>(f_7, _1, 2, 3, 4, 5, 6, 7)(i), (global_result == 7654321L)) );
+    BOOST_TEST( (bind<void>(f_8, _1, 2, 3, 4, 5, 6, 7, 8)(i), (global_result == 87654321L)) );
+    BOOST_TEST( (bind<void>(f_9, _1, 2, 3, 4, 5, 6, 7, 8, 9)(i), (global_result == 987654321L)) );
+}
+
+//
+
+struct Y
+{
+    short operator()(short & r) const { return global_result = ++r; }
+    int operator()(int a, int b) const { return global_result = a + 10 * b; }
+    long operator() (long a, long b, long c) const { return global_result = a + 10 * b + 100 * c; }
+    void operator() (long a, long b, long c, long d) const { global_result = a + 10 * b + 100 * c + 1000 * d; }
+};
+
+void function_object_test()
+{
+    using namespace boost;
+
+    short i(6);
+
+    int const k = 3;
+
+    BOOST_TEST( (bind<void>(Y(), ref(i))(), (global_result == 7)) );
+    BOOST_TEST( (bind<void>(Y(), ref(i))(), (global_result == 8)) );
+    BOOST_TEST( (bind<void>(Y(), i, _1)(k), (global_result == 38)) );
+    BOOST_TEST( (bind<void>(Y(), i, _1, 9)(k), (global_result == 938)) );
+    BOOST_TEST( (bind<void>(Y(), i, _1, 9, 4)(k), (global_result == 4938)) );
+}
+
+int main()
+{
+    function_test();
+    function_object_test();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
While working on this I noticed that `bind<void>` did not work for member functions. Curiously, bind_mf2_cc introduces support for `bind(type<Rt2>, R (T::*f)(...), ...)` and there are tests for `bind(type<void>(), ...)`, but not for the equivalent `bind<void>(...)`. I introduced these additional overloads to bind_mf_cc (since they are not `type<>` based). I fear this might trigger some new overload resolution errors on old compilers.

I composed a test out of pieces of other tests. I included a compilation test for data members, but I don't see a way to test any runtime behavior.

I would like to add some notes to the documentation explicitly stating support for `bind<void>`, any suggestions?