### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -3,7 +3,7 @@
 #   Distributed under the Boost Software License, Version 1.0.
 #   (See accompanying file LICENSE_1_0.txt or copy at
 #   http://www.boost.org/LICENSE_1_0.txt)
-project boost/doc ;
+project bind/doc ;
 import boostbook : boostbook ;
 
 boostbook ref-doc : ref.xml 


### PR DESCRIPTION
There can only be one project called "boost/doc" and this isn't it ;-)

So the patch changes the name to something else.
