### PR TITLE
Add a failing test about ambiguous overload

### DIFF
--- a/test/bind_void_test.cpp
+++ b/test/bind_void_test.cpp
@@ -87,6 +87,11 @@ long f_9(long a, long b, long c, long d, long e, long f, long g, long h, long i)
     return global_result = a + 10 * b + 100 * c + 1000 * d + 10000 * e + 100000 * f + 1000000 * g + 10000000 * h + 100000000 * i;
 }
 
+struct X
+{
+  void f0() { global_result = 1; }
+};
+
 void function_test()
 {
     using namespace boost;
@@ -103,6 +108,8 @@ void function_test()
     BOOST_TEST( (bind<void>(f_7, _1, 2, 3, 4, 5, 6, 7)(i), (global_result == 7654321L)) );
     BOOST_TEST( (bind<void>(f_8, _1, 2, 3, 4, 5, 6, 7, 8)(i), (global_result == 87654321L)) );
     BOOST_TEST( (bind<void>(f_9, _1, 2, 3, 4, 5, 6, 7, 8, 9)(i), (global_result == 987654321L)) );
+
+    BOOST_TEST( (bind<void>(&X::f0, X())(), (global_result == 1L)) );
 }
 
 //


### PR DESCRIPTION
The wrong commit is:
https://github.com/boostorg/bind/commit/30921a3889f3aad1fb9456aa3417f16dcf4c23c1

Failed with gcc 4.9.2 and clang 3.6.0 on linux.

gcc:
```
In file included from ./boost/detail/lightweight_test.hpp:15:0,
                 from libs/bind/test/bind_void_test.cpp:34:
libs/bind/test/bind_void_test.cpp: In function ‘void function_test()’:
libs/bind/test/bind_void_test.cpp:112:40: error: call of overloaded ‘bind(void (X::*)(), X)’ is ambiguous
     BOOST_TEST( (bind<void>(&X::f0, X())(), (global_result == 1L)) );
                                        ^
./boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
libs/bind/test/bind_void_test.cpp:112:40: note: candidates are:
     BOOST_TEST( (bind<void>(&X::f0, X())(), (global_result == 1L)) );
                                        ^
./boost/core/lightweight_test.hpp:146:28: note: in definition of macro ‘BOOST_TEST’
 #define BOOST_TEST(expr) ((expr)? (void)0: ::boost::detail::test_failed_impl(#expr, __FILE__, __LINE__, BOOST_CURRENT_FUNCTION))
                            ^
In file included from ./boost/bind.hpp:22:0,
                 from libs/bind/test/bind_void_test.cpp:21:
./boost/bind/bind.hpp:1579:20: note: boost::_bi::bind_t<R, F, typename boost::_bi::list_av_1<A1>::type> boost::bind(F, A1) [with R = void; F = void (X::*)(); A1 = X; typename boost::_bi::list_av_1<A1>::type = boost::_bi::list1<boost::_bi::value<X> >]
 #define BOOST_BIND bind
                    ^
./boost/bind/bind.hpp:1594:5: note: in expansion of macro ‘BOOST_BIND’
     BOOST_BIND(F f, A1 a1)
     ^
./boost/bind/bind.hpp:1579:20: note: boost::_bi::bind_t<R, boost::_mfi::mf0<R, T>, typename boost::_bi::list_av_1<A1>::type> boost::bind(R (T::*)(), A1) [with R = void; T = X; A1 = X; typename boost::_bi::list_av_1<A1>::type = boost::_bi::list1<boost::_bi::value<X> >]
 #define BOOST_BIND bind
                    ^
./boost/bind/bind_mf_cc.hpp:20:5: note: in expansion of macro ‘BOOST_BIND’
     BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (), A1 a1)
     ^
./boost/bind/bind.hpp:1579:20: note: boost::_bi::bind_t<Rt2, boost::_mfi::mf0<R, T>, typename boost::_bi::list_av_1<A1>::type> boost::bind(R (T::*)(), A1) [with Rt2 = void; R = void; T = X; A1 = X; typename boost::_bi::list_av_1<A1>::type = boost::_bi::list1<boost::_bi::value<X> >]
 #define BOOST_BIND bind
                    ^
./boost/bind/bind_mf_cc.hpp:40:5: note: in expansion of macro ‘BOOST_BIND’
     BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (), A1 a1)
```
