### PR TITLE
Fix compilation with BOOST_BIND_NO_PLACEHOLDERS

### DIFF
--- a/include/boost/bind.hpp
+++ b/include/boost/bind.hpp
@@ -21,6 +21,8 @@
 
 #include <boost/bind/bind.hpp>
 
+#ifndef BOOST_BIND_NO_PLACEHOLDERS
+
 #if defined(BOOST_CLANG)
 # pragma clang diagnostic push
 # if  __has_warning("-Wheader-hygiene")
@@ -33,5 +35,7 @@ using namespace boost::placeholders;
 #if defined(BOOST_CLANG)
 # pragma clang diagnostic pop
 #endif
+
+#endif // #ifndef BOOST_BIND_NO_PLACEHOLDERS
 
 #endif // #ifndef BOOST_BIND_HPP_INCLUDED


### PR DESCRIPTION
If BOOST_BIND_NO_PLACEHOLDERS is defined, there is no namespace boost::placeholders.

The errors are visible in most of the odeint tests:
http://www.boost.org/development/tests/develop/developer/numeric-odeint.html