### PR TITLE
Add minimal cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,20 @@ matrix:
     - env: BOGUS_JOB=true
 
   include:
+
+      # cmake self-test
+    - os: linux
+      env: TEST_CMAKE=TRUE #Only for easier identification in travis web gui
+      install:
+        - git clone --depth 1 https://github.com/boostorg/config.git ../config
+        - git clone --depth 1 https://github.com/boostorg/core.git ../core
+        - git clone --depth 1 https://github.com/boostorg/assert.git ../assert
+
+      script:
+        - mkdir __build__ && cd __build__
+        - cmake ../test/test_cmake
+        - cmake --build .
+
     - os: linux
       compiler: g++
       env: TOOLSET=gcc COMPILER=g++ CXXSTD=03,11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # Copyright 2018 Mike Dev
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Bind is currently experimental at best
+#       and the interface is likely to change in the future
 
 cmake_minimum_required(VERSION 3.5)
 project(BoostBind LANGUAGES CXX)
@@ -15,4 +18,3 @@ target_link_libraries(boost_bind
         Boost::config
         Boost::core
 )
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostBind LANGUAGES CXX)
+
+add_library(boost_bind INTERFACE)
+add_library(Boost::bind ALIAS boost_bind)
+
+target_include_directories(boost_bind INTERFACE include)
+
+target_link_libraries(boost_bind
+    INTERFACE
+        Boost::config
+        Boost::core
+)
+

--- a/test/test_cmake/CMakeLists.txt
+++ b/test/test_cmake/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: This does NOT run the unit tests for Boost.Bind.
+#       It only tests, if the CMakeLists.txt file in it's root works as expected
+
+cmake_minimum_required( VERSION 3.5 )
+
+project( BoostBindCMakeSelfTest )
+
+add_subdirectory( ../../../config ${CMAKE_CURRENT_BINARY_DIR}/libs/config )
+add_subdirectory( ../../../core ${CMAKE_CURRENT_BINARY_DIR}/libs/core )
+add_subdirectory( ../../../assert ${CMAKE_CURRENT_BINARY_DIR}/libs/assert )
+
+add_subdirectory( ../.. ${CMAKE_CURRENT_BINARY_DIR}/libs/boost_bind )
+
+add_executable( boost_bind_cmake_self_test main.cpp )
+target_link_libraries( boost_bind_cmake_self_test Boost::bind )
+

--- a/test/test_cmake/main.cpp
+++ b/test/test_cmake/main.cpp
@@ -1,0 +1,5 @@
+#include <boost/bind.hpp>
+
+int main() {
+
+}


### PR DESCRIPTION
I hope I am wrong, but it sappears that the coordinated effort by Robert ramey to introduce a comprehensive cmake solution has stalled for now, so I'm going to continue to offer minimal cmake filles like this for individual boost libraries, whenever I find the time for it.


