### PR TITLE
Fix Windows call conventions tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,9 @@ branches:
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0
+      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-14.0
+      TOOLSET: msvc-12.0,msvc-14.0
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       TOOLSET: msvc-14.1
       CXXSTD: 14,17
@@ -38,4 +38,5 @@ build: off
 
 test_script:
   - if not "%CXXSTD%" == "" set CXXSTD=cxxstd=%CXXSTD%
-  - b2 -j 3 libs/bind/test toolset=%TOOLSET% %CXXSTD%
+  - if not "%TOOLSET%" == "msvc-9.0,msvc-10.0,msvc-11.0" set ADDRMDL=address-model=32,64
+  - b2 -j 3 libs/bind/test toolset=%TOOLSET% %CXXSTD% %ADDRMDL%

--- a/test/bind_cdecl_mf_test.cpp
+++ b/test/bind_cdecl_mf_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/bind_fastcall_mf_test.cpp
+++ b/test/bind_fastcall_mf_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/bind_fastcall_test.cpp
+++ b/test/bind_fastcall_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/bind_stdcall_mf_test.cpp
+++ b/test/bind_stdcall_mf_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/bind_stdcall_test.cpp
+++ b/test/bind_stdcall_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/mem_fn_cdecl_test.cpp
+++ b/test/mem_fn_cdecl_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/mem_fn_fastcall_test.cpp
+++ b/test/mem_fn_fastcall_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {

--- a/test/mem_fn_stdcall_test.cpp
+++ b/test/mem_fn_stdcall_test.cpp
@@ -1,6 +1,6 @@
 #include <boost/config.hpp>
 
-#ifndef BOOST_MSVC
+#if !defined(_WIN32) || defined(_WIN64) || defined(__MINGW64__)
 
 int main()
 {


### PR DESCRIPTION
Currently the tests incorrectly limited to MSVC and also run on 64bit build.
After the change 32bit Clang and MinGW will be tested, and 64bit MSVC will be skipped.