### PR TITLE
refactor: use boost/bind/mem_fn over boost/mem_fn

### DIFF
--- a/include/boost/bind/bind.hpp
+++ b/include/boost/bind/bind.hpp
@@ -23,7 +23,7 @@
 
 #include <boost/config.hpp>
 #include <boost/ref.hpp>
-#include <boost/mem_fn.hpp>
+#include <boost/bind/mem_fn.hpp>
 #include <boost/type.hpp>
 #include <boost/is_placeholder.hpp>
 #include <boost/bind/arg.hpp>


### PR DESCRIPTION
The later just includes the former. i.e contents of `boost/mem_fn.hpp`:
```cpp
#ifndef BOOST_MEM_FN_HPP_INCLUDED
#define BOOST_MEM_FN_HPP_INCLUDED

// MS compatible compilers support #pragma once

#if defined(_MSC_VER) && (_MSC_VER >= 1020)
# pragma once
#endif

//
//  mem_fn.hpp - a generalization of std::mem_fun[_ref]
//
//  Copyright (c) 2009 Peter Dimov
//
//  Distributed under the Boost Software License, Version 1.0.
//  See accompanying file LICENSE_1_0.txt or copy at
//  http://www.boost.org/LICENSE_1_0.txt
//
//  See http://www.boost.org/libs/bind/mem_fn.html for documentation.
//

#include <boost/bind/mem_fn.hpp>

#endif // #ifndef BOOST_MEM_FN_HPP_INCLUDED
```