### PR TITLE
Use `is_same` from Boost.TypeTraits

### DIFF
--- a/include/boost/bind/bind.hpp
+++ b/include/boost/bind/bind.hpp
@@ -22,7 +22,6 @@
 //
 
 #include <boost/config.hpp>
-#include <boost/ref.hpp>
 #include <boost/bind/mem_fn.hpp>
 #include <boost/type.hpp>
 #include <boost/is_placeholder.hpp>
@@ -31,8 +30,9 @@
 #include <boost/bind/std_placeholders.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/visit_each.hpp>
+#include <boost/core/ref.hpp>
 #include <boost/core/enable_if.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/bind/detail/is_same.hpp>
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 #include <utility> // std::forward

--- a/include/boost/bind/bind_mf_cc.hpp
+++ b/include/boost/bind/bind_mf_cc.hpp
@@ -36,7 +36,7 @@ template<class R, class T,
 
 template<class Rt2, class R, class T,
     class A1>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf0)<R, T>, typename _bi::list_av_1<A1>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) () BOOST_BIND_MF_NOEXCEPT, A1 a1)
 {
@@ -47,7 +47,7 @@ template<class Rt2, class R, class T,
 
 template<class Rt2, class R, class T,
     class A1>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf0)<R, T>, typename _bi::list_av_1<A1>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) () const BOOST_BIND_MF_NOEXCEPT, A1 a1)
 {
@@ -83,7 +83,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1,
     class A1, class A2>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf1)<R, T, B1>, typename _bi::list_av_2<A1, A2>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2)
 {
@@ -95,7 +95,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1,
     class A1, class A2>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf1)<R, T, B1>, typename _bi::list_av_2<A1, A2>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2)
 {
@@ -131,7 +131,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2,
     class A1, class A2, class A3>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf2)<R, T, B1, B2>, typename _bi::list_av_3<A1, A2, A3>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3)
 {
@@ -143,7 +143,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2,
     class A1, class A2, class A3>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf2)<R, T, B1, B2>, typename _bi::list_av_3<A1, A2, A3>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3)
 {
@@ -179,7 +179,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3,
     class A1, class A2, class A3, class A4>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf3)<R, T, B1, B2, B3>, typename _bi::list_av_4<A1, A2, A3, A4>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4)
 {
@@ -191,7 +191,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3,
     class A1, class A2, class A3, class A4>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf3)<R, T, B1, B2, B3>, typename _bi::list_av_4<A1, A2, A3, A4>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4)
 {
@@ -227,7 +227,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4,
     class A1, class A2, class A3, class A4, class A5>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf4)<R, T, B1, B2, B3, B4>, typename _bi::list_av_5<A1, A2, A3, A4, A5>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
 {
@@ -239,7 +239,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4,
     class A1, class A2, class A3, class A4, class A5>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf4)<R, T, B1, B2, B3, B4>, typename _bi::list_av_5<A1, A2, A3, A4, A5>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5)
 {
@@ -275,7 +275,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5,
     class A1, class A2, class A3, class A4, class A5, class A6>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf5)<R, T, B1, B2, B3, B4, B5>, typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
 {
@@ -287,7 +287,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5,
     class A1, class A2, class A3, class A4, class A5, class A6>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf5)<R, T, B1, B2, B3, B4, B5>, typename _bi::list_av_6<A1, A2, A3, A4, A5, A6>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6)
 {
@@ -323,7 +323,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf6)<R, T, B1, B2, B3, B4, B5, B6>, typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
 {
@@ -335,7 +335,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf6)<R, T, B1, B2, B3, B4, B5, B6>, typename _bi::list_av_7<A1, A2, A3, A4, A5, A6, A7>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7)
 {
@@ -371,7 +371,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6, class B7,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf7)<R, T, B1, B2, B3, B4, B5, B6, B7>, typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
 {
@@ -383,7 +383,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6, class B7,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf7)<R, T, B1, B2, B3, B4, B5, B6, B7>, typename _bi::list_av_8<A1, A2, A3, A4, A5, A6, A7, A8>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8)
 {
@@ -419,7 +419,7 @@ template<class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6, class B7, class B8,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(mf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8>, typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7, B8) BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
 {
@@ -431,7 +431,7 @@ template<class Rt2, class R, class T,
 template<class Rt2, class R, class T,
     class B1, class B2, class B3, class B4, class B5, class B6, class B7, class B8,
     class A1, class A2, class A3, class A4, class A5, class A6, class A7, class A8, class A9>
-    typename boost::enable_if_c<!boost::core::is_same<Rt2, R>::value,
+    typename boost::enable_if_c<!_bi::is_same<Rt2, R>::value,
     _bi::bind_t<Rt2, _mfi::BOOST_BIND_MF_NAME(cmf8)<R, T, B1, B2, B3, B4, B5, B6, B7, B8>, typename _bi::list_av_9<A1, A2, A3, A4, A5, A6, A7, A8, A9>::type>
     >::type BOOST_BIND(R (BOOST_BIND_MF_CC T::*f) (B1, B2, B3, B4, B5, B6, B7, B8) const BOOST_BIND_MF_NOEXCEPT, A1 a1, A2 a2, A3 a3, A4 a4, A5 a5, A6 a6, A7 a7, A8 a8, A9 a9)
 {

--- a/include/boost/bind/detail/is_same.hpp
+++ b/include/boost/bind/detail/is_same.hpp
@@ -1,0 +1,36 @@
+#ifndef BOOST_BIND_DETAIL_IS_SAME_HPP_INCLUDED
+#define BOOST_BIND_DETAIL_IS_SAME_HPP_INCLUDED
+
+// is_same<T1,T2>::value is true when T1 == T2
+//
+// Copyright 2014 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+#endif
+
+namespace boost
+{
+namespace _bi
+{
+
+template< class T1, class T2 > struct is_same
+{
+    BOOST_STATIC_CONSTANT( bool, value = false );
+};
+
+template< class T > struct is_same< T, T >
+{
+    BOOST_STATIC_CONSTANT( bool, value = true );
+};
+
+} // namespace _bi
+} // namespace boost
+
+#endif // #ifndef BOOST_BIND_DETAIL_IS_SAME_HPP_INCLUDED

--- a/include/boost/bind/detail/result_traits.hpp
+++ b/include/boost/bind/detail/result_traits.hpp
@@ -22,6 +22,7 @@
 //
 
 #include <boost/config.hpp>
+#include <boost/core/ref.hpp>
 
 #if BOOST_CXX_VERSION >= 201700L
 #include <functional>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,6 @@ include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
 
 if(HAVE_BOOST_TEST)
 
-boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::bind Boost::core Boost::function Boost::smart_ptr)
+boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::bind Boost::core Boost::function Boost::smart_ptr Boost::type_traits)
 
 endif()

--- a/test/apply_test2.cpp
+++ b/test/apply_test2.cpp
@@ -4,12 +4,12 @@
 
 #include <boost/bind/apply.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 int main()
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<void, boost::apply<void>::result_type>));
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<int&, boost::apply<int&>::result_type>));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<void, boost::apply<void>::result_type>));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<int&, boost::apply<int&>::result_type>));
 
     return boost::report_errors();
 }

--- a/test/protect_test2.cpp
+++ b/test/protect_test2.cpp
@@ -6,11 +6,11 @@
 
 #include <boost/bind/protect.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
-#include <boost/core/is_same.hpp>
+#include <boost/type_traits/is_same.hpp>
 
 template<class T, class F> void test( F )
 {
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<typename T::result_type, typename F::result_type>));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<typename T::result_type, typename F::result_type>));
 }
 
 struct X
@@ -29,7 +29,7 @@ template<class T, class U> struct inherit: T, U
 template<class F> void test2( F )
 {
     // test that F doesn't have ::result_type
-    BOOST_TEST_TRAIT_TRUE((boost::core::is_same<typename inherit<F, X>::result_type, typename X::result_type>));
+    BOOST_TEST_TRAIT_TRUE((boost::is_same<typename inherit<F, X>::result_type, typename X::result_type>));
 }
 
 int main()


### PR DESCRIPTION
`boost::core::is_same` is deprecated, so use the one from Boost.TypeTraits.

Note: This introduces a dependency on Boost.TypeTraits. I figured, this is better than duplicating `is_same` or depending on `boost::core::detail::is_same`. Boost.TypeTraits is a fairly lightweight nowdays. If you prefer a different solution, let me know.
