### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -7,8 +7,8 @@ import project ;
 
 project /boost/bind
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,21 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/bind
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <include>include
+    ;
+
+explicit
+    [ alias boost_bind ]
+    [ alias all : boost_bind test ]
+    ;
+
+call-if : boost-library bind
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/bind
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/bind

--- a/build.jam
+++ b/build.jam
@@ -5,17 +5,20 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/core//boost_core ;
+
 project /boost/bind
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
         <include>include
     ;
 
 explicit
-    [ alias boost_bind ]
+    [ alias boost_bind : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_bind test ]
     ;
 
 call-if : boost-library bind
     ;
+

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -26,6 +26,11 @@ project
     <toolset>clang:<cxxflags>$(gcc-flags)
   ;
 
+project : requirements
+    <source>/boost/smart_ptr//boost_smart_ptr
+    <source>/boost/function//boost_function
+    ;
+
 # quick test (for CI)
 run quick.cpp ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -27,8 +27,8 @@ project
   ;
 
 project : requirements
-    <source>/boost/smart_ptr//boost_smart_ptr
-    <source>/boost/function//boost_function
+    <library>/boost/smart_ptr//boost_smart_ptr
+    <library>/boost/function//boost_function
     ;
 
 # quick test (for CI)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,9 +24,8 @@ project
 
     <toolset>gcc:<cxxflags>$(gcc-flags)
     <toolset>clang:<cxxflags>$(gcc-flags)
-  ;
 
-project : requirements
+    <library>/boost/bind//boost_bind
     <library>/boost/smart_ptr//boost_smart_ptr
     <library>/boost/function//boost_function
     ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.