### PR TITLE
Remove redundant parenthesis on typedef

### DIFF
--- a/include/boost/bind/mem_fn.hpp
+++ b/include/boost/bind/mem_fn.hpp
@@ -179,7 +179,7 @@ public:
 
 private:
 
-    typedef R (T::*Pm);
+    typedef R T::*Pm;
     Pm pm_;
 
 public:


### PR DESCRIPTION
When compiling with clang 19.1.7 on Alma with `-Werror` and a number of other flags (we run with most warnings enabled), the line is flagged with `error: redundant parentheses surrounding declarator [-Werror, -Wredundant-parens]`.

Env:
Alma 9.6
Boost 1.88.0 via cmake
clang 19.1.7